### PR TITLE
Compatibility with PrestaShop 1.7 & Payment Method Mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - export of tax rules, will no longer be exported when no taxes are assigned
+- replaced deprecated method call to fix product export and increase compatibility with PrestaShop 1.7
+
+### Added
+- default payment method mapping for invoice and SIX Saferpay
 
 ## [2.9.85] - 2018-02-01
 ### Fixed

--- a/src/classes/items/item/Item.php
+++ b/src/classes/items/item/Item.php
@@ -1238,7 +1238,7 @@ class ShopgateItemsItem extends ShopgateItemsAbstract
             $shopId,
             $itemId,
             $variantId,
-            (int)Country::getDefaultCountryId(),
+            (int)Context::getContext()->country->id,
             0,
             0,
             (int)(Validate::isLoadedObject($this->getPlugin()->getContext()->currency)

--- a/src/config/payment.xml
+++ b/src/config/payment.xml
@@ -26,4 +26,12 @@
         <name>Bankwire</name>
         <not_blocked_not_paid>PS_OS_BANKWIRE</not_blocked_not_paid>
     </prepay>
+    <invoice>
+        <key>INVOICE</key>
+        <name>Invoice</name>
+    </invoice>
+    <cc_six_saferpay>
+        <key>SIX_CC</key>
+        <name>Credit Card</name>
+    </cc_six_saferpay>
 </payments>

--- a/src/de.php
+++ b/src/de.php
@@ -42,6 +42,8 @@ $_MODULE['<{shopgate}prestashop>shopgate_5adcc6231aa37b272b4fd42d9067c3f0']     
 $_MODULE['<{shopgate}prestashop>shopgate_35b4b09d5d0686ec5c2e2cc9f3d9039c']         = 'Vorkasse';
 $_MODULE['<{shopgate}prestashop>shopgate_469ded86e4fce0e962b4d91cc7d426ce']         = 'Nachnahme';
 $_MODULE['<{shopgate}prestashop>shopgate_ad69e733ebae8d264bccaa38d68830e8']         = 'PayPal';
+$_MODULE['<{shopgate}prestashop>payment_466eadd40b3c10580e3ab4e8061161ce']          = 'Rechnung';
+$_MODULE['<{shopgate}prestashop>payment_73a61696f100b3858511e212a3feea6b']          = 'Kreditkarte';
 $_MODULE['<{shopgate}prestashop>shopgate_134c858fbc1e4f57acbe5e24ec507a7f']         = 'Mobile Payment';
 $_MODULE['<{shopgate}prestashop>shopgate_581568a8b927474e702ec083e3ab8daf']         = 'Hängt von der bei Shopgate ausgewählten Versandmethode ab';
 $_MODULE['<{shopgate}prestashop>shopgate_a02e49b5d07e5de5544bde8ea63dbeeb']         = 'Versand blockiert (Shopgate)';


### PR DESCRIPTION
### Fixed
- replaced deprecated method call to fix product export and increase compatibility with PrestaShop 1.7

### Added
- default payment method mapping for invoice and SIX Saferpay

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
